### PR TITLE
Decouple platform-related stuff from Graphics

### DIFF
--- a/android/src/playn/android/AndroidAssets.java
+++ b/android/src/playn/android/AndroidAssets.java
@@ -223,7 +223,7 @@ public class AndroidAssets extends Assets {
     throw error != null ? error : new FileNotFoundException(path);
   }
 
-  Typeface getTypeface(String path) {
+  public Typeface getTypeface(String path) {
     return Typeface.createFromAsset(assetMgr, normalizePath(pathPrefix + path));
   }
 

--- a/android/src/playn/android/AndroidGraphics.java
+++ b/android/src/playn/android/AndroidGraphics.java
@@ -43,7 +43,7 @@ public class AndroidGraphics extends Graphics {
     void onSurfaceCreated();
   }
 
-  private final AndroidPlatform plat;
+  private final Platform plat;
   private final Point touchTemp = new Point();
 
   private Map<Refreshable, Void> refreshables =
@@ -63,8 +63,8 @@ public class AndroidGraphics extends Graphics {
 
   final Bitmap.Config preferredBitmapConfig;
 
-  public AndroidGraphics(AndroidPlatform plat, Bitmap.Config bitmapConfig) {
-    super(plat, new AndroidGL20(), new Scale(plat.activity.scaleFactor()));
+  public AndroidGraphics(Platform plat, Bitmap.Config bitmapConfig, float scaleFactor) {
+    super(plat, new AndroidGL20(), new Scale(scaleFactor));
     this.plat = plat;
     this.preferredBitmapConfig = bitmapConfig;
   }
@@ -80,29 +80,7 @@ public class AndroidGraphics extends Graphics {
   /**
    * Registers a font with the graphics system.
    *
-   * @param path the path to the font resource (relative to the asset manager's path prefix).
-   * @param name the name under which to register the font.
-   * @param style the style variant of the specified name provided by the font file. For example
-   * one might {@code registerFont("myfont.ttf", "My Font", Font.Style.PLAIN)} and
-   * {@code registerFont("myfontb.ttf", "My Font", Font.Style.BOLD)} to provide both the plain and
-   * bold variants of a particular font.
-   * @param ligatureGlyphs any known text sequences that are converted into a single ligature
-   * character in this font. This works around an Android bug where measuring text for wrapping
-   * that contains character sequences that are converted into ligatures (e.g. "fi" or "ae")
-   * incorrectly reports the number of characters "consumed" from the to-be-wrapped string.
-   */
-  public void registerFont(String path, String name, Font.Style style, String... ligatureGlyphs) {
-    try {
-      registerFont(plat.assets().getTypeface(path), name, style, ligatureGlyphs);
-    } catch (Exception e) {
-      plat.reportError("Failed to load font [name=" + name + ", path=" + path + "]", e);
-    }
-  }
-
-  /**
-   * Registers a font with the graphics system.
-   *
-   * @param face the typeface to be registered.
+   * @param face the typeface to be registered. It can be loaded via {@code plat.assets().getTypeface}.
    * @param name the name under which to register the font.
    * @param style the style variant of the specified name provided by the font file. For example
    * one might {@code registerFont("myfont.ttf", "My Font", Font.Style.PLAIN)} and

--- a/android/src/playn/android/AndroidGraphics.java
+++ b/android/src/playn/android/AndroidGraphics.java
@@ -69,7 +69,7 @@ public class AndroidGraphics extends Graphics {
     this.preferredBitmapConfig = bitmapConfig;
   }
 
-  void onSizeChanged(int viewWidth, int viewHeight) {
+  public void setSize(int viewWidth, int viewHeight) {
     screenSize.width = viewWidth / scale.factor;
     screenSize.height = viewHeight / scale.factor;
     plat.log().info("Updating size " + viewWidth + "x" + viewHeight + " / " + scale.factor +

--- a/android/src/playn/android/AndroidGraphics.java
+++ b/android/src/playn/android/AndroidGraphics.java
@@ -43,7 +43,6 @@ public class AndroidGraphics extends Graphics {
     void onSurfaceCreated();
   }
 
-  private final Platform plat;
   private final Point touchTemp = new Point();
 
   private Map<Refreshable, Void> refreshables =
@@ -65,16 +64,13 @@ public class AndroidGraphics extends Graphics {
 
   public AndroidGraphics(Platform plat, Bitmap.Config bitmapConfig, float scaleFactor) {
     super(plat, new AndroidGL20(), new Scale(scaleFactor));
-    this.plat = plat;
     this.preferredBitmapConfig = bitmapConfig;
   }
 
-  public void setSize(int viewWidth, int viewHeight) {
+  @Override public void setSize(int viewWidth, int viewHeight) {
     screenSize.width = viewWidth / scale.factor;
     screenSize.height = viewHeight / scale.factor;
-    plat.log().info("Updating size " + viewWidth + "x" + viewHeight + " / " + scale.factor +
-                    " -> " + screenSize);
-    viewportChanged(scale, viewWidth, viewHeight);
+    super.setSize(viewWidth, viewHeight);
   }
 
   /**

--- a/android/src/playn/android/AndroidPlatform.java
+++ b/android/src/playn/android/AndroidPlatform.java
@@ -17,7 +17,6 @@ package playn.android;
 
 import android.content.Intent;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.util.Log;
 
 import playn.core.*;
@@ -51,7 +50,7 @@ public class AndroidPlatform extends Platform {
       @Override protected boolean isPaused () { return state == State.PAUSED; }
     };
     audio = new AndroidAudio(this);
-    graphics = new AndroidGraphics(this, activity.preferredBitmapConfig());
+    graphics = new AndroidGraphics(this, activity.preferredBitmapConfig(), activity.scaleFactor());
     assets = new AndroidAssets(this);
     json = new JsonImpl();
     input = new AndroidInput(this);

--- a/android/src/playn/android/GameViewGL.java
+++ b/android/src/playn/android/GameViewGL.java
@@ -43,7 +43,7 @@ public class GameViewGL extends GLSurfaceView {
         plat.graphics().onSurfaceCreated();
       }
       @Override public void onSurfaceChanged(GL10 gl, int width, int height) {
-        plat.graphics().onSizeChanged(width, height);
+        plat.graphics().setSize(width, height);
         // we defer the start of the game until we've received our initial surface size
         if (!started.get()) startGame();
       }

--- a/core/src/playn/core/Graphics.java
+++ b/core/src/playn/core/Graphics.java
@@ -60,6 +60,20 @@ public abstract class Graphics {
   public abstract IDimension screenSize ();
 
   /**
+   * Changes the size of the PlayN window. The supplied size is in display units, it will be
+   * converted to pixels based on the display scale factor.
+   */
+  public void setSize (int width, int height){
+    plat.log().info("Updating size " + width + "x" + height + " / " + scale.factor +
+        " -> " + screenSize());
+    
+    viewPixelWidth = width;
+    viewPixelHeight = height;
+    viewSizeM.width = scale.invScaled(width);
+    viewSizeM.height = scale.invScaled(height);
+  }
+
+  /**
    * Creates a {@link Canvas} with the specified display unit size.
    */
   public Canvas createCanvas (float width, float height) {
@@ -146,14 +160,6 @@ public abstract class Graphics {
    * Informs the graphics system that the main viewport size or scale has changed. The supplied
    * size should be in physical pixels.
    */
-  protected void viewportChanged (Scale scale, int viewWidth, int viewHeight) {
-    this.scale = scale;
-    viewPixelWidth = viewWidth;
-    viewPixelHeight = viewHeight;
-    viewSizeM.width = scale.invScaled(viewWidth);
-    viewSizeM.height = scale.invScaled(viewHeight);
-    // TODO: allow listening for view size change?
-  }
 
   int createTexture (Texture.Config config) {
     int id = gl.glGenTexture();

--- a/html/src/playn/html/HtmlGraphics.java
+++ b/html/src/playn/html/HtmlGraphics.java
@@ -56,7 +56,7 @@ public class HtmlGraphics extends Graphics {
   // Temporary hack to fix mouse coordinates for scaled fullscreen mode.
   static float experimentalScale = 1;
 
-  public HtmlGraphics(HtmlPlatform plat, HtmlPlatform.Config config) {
+  public HtmlGraphics(Platform plat, HtmlPlatform.Config config) {
     super(plat, new HtmlGL20(), new Scale(config.scaleFactor));
 
     Document doc = Document.get();

--- a/html/src/playn/html/HtmlGraphics.java
+++ b/html/src/playn/html/HtmlGraphics.java
@@ -133,7 +133,7 @@ public class HtmlGraphics extends Graphics {
    * understood by page elements. If the page is actually being dispalyed on a HiDPI (Retina)
    * device, the actual framebuffer may be 2x (or larger) the specified size.
    */
-  public void setSize (int width, int height) {
+  @Override public void setSize (int width, int height) {
     rootElement.getStyle().setWidth(width, Unit.PX);
     rootElement.getStyle().setHeight(height, Unit.PX);
     // set the canvas size to the pixel size, this controls the framebuffer size
@@ -143,7 +143,7 @@ public class HtmlGraphics extends Graphics {
     // displayed at the proper size in the page
     canvas.getStyle().setWidth(width, Style.Unit.PX);
     canvas.getStyle().setHeight(height, Style.Unit.PX);
-    viewportChanged(scale, canvas.getWidth(), canvas.getHeight());
+    super.setSize(canvas.getWidth(), canvas.getHeight());
     plat.log().info("FB " + viewPixelWidth + "x" + viewPixelHeight + " LG " + viewSize);
   }
 

--- a/java-base/src/playn/java/JavaAssets.java
+++ b/java-base/src/playn/java/JavaAssets.java
@@ -150,6 +150,21 @@ public class JavaAssets extends Assets {
   }
 
   /**
+   * Get a font from the given path.
+   *  
+   * @param path the path to the font resource (relative to the asset manager's path prefix).
+   * Currently only TrueType ({@code .ttf}) fonts are supported.
+   */
+  public Font getFont(String path) throws IOException{
+    try {
+      return requireResource(path).createFont();
+    } catch (Exception e) {
+      plat.reportError("Failed to load font from "  + path, e);
+      return null;
+    }
+  }
+  
+  /**
    * Attempts to locate the resource at the given path, and returns a wrapper which allows its data
    * to be efficiently read.
    *
@@ -157,7 +172,7 @@ public class JavaAssets extends Assets {
    * loader checked. If not found, then the extra directories, if any, are checked, in order. If
    * the file is not found in any of the extra directories either, then an exception is thrown.
    */
-  protected Resource requireResource(String path) throws IOException {
+  public Resource requireResource(String path) throws IOException {
     URL url = getClass().getClassLoader().getResource(pathPrefix + path);
     if (url != null) {
       return url.getProtocol().equals("file") ?

--- a/java-base/src/playn/java/JavaGraphics.java
+++ b/java-base/src/playn/java/JavaGraphics.java
@@ -88,7 +88,8 @@ public abstract class JavaGraphics extends Graphics {
   protected abstract void upload (BufferedImage img, Texture tex);
 
   protected void updateViewport (Scale scale, float displayWidth, float displayHeight) {
-    viewportChanged(scale, scale.scaledCeil(displayWidth), scale.scaledCeil(displayHeight));
+    this.scale = scale;
+    setSize(scale.scaledCeil(displayWidth), scale.scaledCeil(displayHeight));
   }
 
   java.awt.Font resolveFont(Font font) {

--- a/java-base/src/playn/java/JavaGraphics.java
+++ b/java-base/src/playn/java/JavaGraphics.java
@@ -31,15 +31,16 @@ public abstract class JavaGraphics extends Graphics {
   private ByteBuffer imgBuf = createImageBuffer(1024);
   private Map<String,java.awt.Font> fonts = new HashMap<String,java.awt.Font>();
 
-  protected final JavaPlatform plat;
+  protected final Platform plat;
+  protected final JavaPlatform.Config config;
 
   // antialiased font context and aliased font context
   final FontRenderContext aaFontContext, aFontContext;
 
-  protected JavaGraphics(JavaPlatform plat, GL20 gl20, Scale scale) {
+  protected JavaGraphics(Platform plat, JavaPlatform.Config config, GL20 gl20, Scale scale) {
     super(plat, gl20, scale);
     this.plat = plat;
-
+    this.config = config;
     // set up the dummy font contexts
     Graphics2D aaGfx = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB).createGraphics();
     aaGfx.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -53,15 +54,11 @@ public abstract class JavaGraphics extends Graphics {
    * Registers a font with the graphics system.
    *
    * @param name the name under which to register the font.
-   * @param path the path to the font resource (relative to the asset manager's path prefix).
-   * Currently only TrueType ({@code .ttf}) fonts are supported.
+   * @param font the AWT font which can be loaded from a path via {@code plat.assets().getFont(path)}
    */
-  public void registerFont (String name, String path) {
-    try {
-      fonts.put(name, plat.assets().requireResource(path).createFont());
-    } catch (Exception e) {
-      plat.reportError("Failed to load font [name=" + name + ", path=" + path + "]", e);
-    }
+  public void registerFont (String name, java.awt.Font font) {
+    if (font == null) return;
+    fonts.put(name, font);
   }
 
   /**

--- a/java-base/src/playn/java/JavaPlatform.java
+++ b/java-base/src/playn/java/JavaPlatform.java
@@ -99,13 +99,13 @@ public abstract class JavaPlatform extends Platform {
     @Override public void setTitle (String title) {} // noop!
     @Override protected void preInit () {}
     @Override protected JavaGraphics createGraphics () {
-      return new JavaGraphics(this, null, Scale.ONE) {
-        /*ctor*/ { setSize(plat.config.width, plat.config.height, plat.config.fullscreen); }
+      return new JavaGraphics(this,config, null, Scale.ONE) {
+        /*ctor*/ { setSize(config.width, config.height, config.fullscreen); }
         @Override public void setSize (int width, int height, boolean fullscreen) {
           updateViewport(Scale.ONE, width, height);
         }
         @Override public IDimension screenSize () {
-          return new Dimension(plat.config.width, plat.config.height);
+          return new Dimension(config.width, config.height);
         }
         @Override protected void init () {} // noop!
         @Override protected void upload (BufferedImage img, Texture tex) {} // noop!

--- a/java-lwjgl/src/playn/java/LWJGLGraphics.java
+++ b/java-lwjgl/src/playn/java/LWJGLGraphics.java
@@ -35,7 +35,7 @@ public class LWJGLGraphics extends JavaGraphics {
   private Dimension screenSize = new Dimension();
 
   public LWJGLGraphics(JavaPlatform plat) {
-    super(plat, new LWJGLGL20(), Scale.ONE); // real scale factor set in init()
+    super(plat, plat.config, new LWJGLGL20(), Scale.ONE); // real scale factor set in init()
   }
 
   void checkScaleFactor () {
@@ -56,8 +56,7 @@ public class LWJGLGraphics extends JavaGraphics {
   }
 
   @Override protected void init () {
-    setDisplayMode(scale.scaledCeil(plat.config.width), scale.scaledCeil(plat.config.height),
-                   plat.config.fullscreen);
+    setDisplayMode(scale.scaledCeil(config.width), scale.scaledCeil(config.height), config.fullscreen);
     try {
       System.setProperty("org.lwjgl.opengl.Display.enableHighDPI", "true");
       Display.create();

--- a/java-swt/src/playn/java/SWTGraphics.java
+++ b/java-swt/src/playn/java/SWTGraphics.java
@@ -15,15 +15,15 @@
  */
 package playn.java;
 
-import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
-import org.eclipse.swt.widgets.*;
-
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.opengl.GLCanvas;
 import org.eclipse.swt.opengl.GLData;
-
-import org.lwjgl.opengl.GLContext;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
 import org.lwjgl.LWJGLException;
+import org.lwjgl.opengl.GLContext;
 
 public class SWTGraphics extends LWJGLGraphics {
 
@@ -48,8 +48,7 @@ public class SWTGraphics extends LWJGLGraphics {
         comp.setBounds(bounds);
         canvas.setBounds(bounds);
         makeCurrent();
-        // SWTGraphics.this.plat.log().info("Resized " + bounds.width + "x" + bounds.height);
-        viewportChanged(scale, bounds.width, bounds.height);
+        setSize(bounds.width, bounds.height);
       }
     });
 

--- a/robovm/src/playn/robovm/RoboGraphics.java
+++ b/robovm/src/playn/robovm/RoboGraphics.java
@@ -112,7 +112,7 @@ public class RoboGraphics extends Graphics {
   }
 
   // called when our view changes size (at init, and when it rotates)
-  void setSize(CGRect bounds) {
+  public void setSize(CGRect bounds) {
     // boolean useHalfSize = useHalfSize(plat);
     int viewWidth = scale.scaledCeil((float)bounds.getWidth());
     int viewHeight = scale.scaledCeil((float)bounds.getHeight());

--- a/robovm/src/playn/robovm/RoboGraphics.java
+++ b/robovm/src/playn/robovm/RoboGraphics.java
@@ -36,7 +36,8 @@ public class RoboGraphics extends Graphics {
   // a shared colorspace instance for use all over the place
   static final CGColorSpace colorSpace = CGColorSpace.createDeviceRGB();
 
-  final RoboPlatform plat;
+  final Platform plat;
+  final private RoboPlatform.Config config;
   private final float touchScale;
   private final Point touchTemp = new Point();
   private final Dimension screenSize = new Dimension();
@@ -46,20 +47,21 @@ public class RoboGraphics extends Graphics {
   private static final int S_SIZE = 10;
   final CGBitmapContext scratchCtx = createCGBitmap(S_SIZE, S_SIZE);
 
-  private static boolean useHalfSize (RoboPlatform plat) {
+  private static boolean useHalfSize (RoboPlatform.Config config) {
     boolean isPad = UIDevice.getCurrentDevice().getUserInterfaceIdiom() == UIUserInterfaceIdiom.Pad;
-    return isPad && plat.config.iPadLikePhone;
+    return isPad && config.iPadLikePhone;
   }
-  private static Scale viewScale (RoboPlatform plat) {
+  private static Scale viewScale (RoboPlatform.Config config) {
     float deviceScale = (float)UIScreen.getMainScreen().getScale();
-    boolean useHalfSize = useHalfSize(plat);
+    boolean useHalfSize = useHalfSize(config);
     return new Scale((useHalfSize ? 2 : 1) * deviceScale);
   }
 
-  public RoboGraphics(RoboPlatform plat, CGRect bounds) {
-    super(plat, new RoboGL20(), viewScale(plat));
+  public RoboGraphics(Platform plat,RoboPlatform.Config config, CGRect bounds) {
+    super(plat, new RoboGL20(), viewScale(config));
     this.plat = plat;
-    this.touchScale = useHalfSize(plat) ? 2 : 1;
+    this.config = config;
+    this.touchScale = useHalfSize(config) ? 2 : 1;
     setSize(bounds);
   }
 
@@ -72,7 +74,7 @@ public class RoboGraphics extends Graphics {
     // tODO: (plat.osVersion < 8) manually flip width/height when in landscape?
     screenSize.width = (int)screenBounds.getWidth();
     screenSize.height = (int)screenBounds.getHeight();
-    if (useHalfSize(plat)) {
+    if (useHalfSize(config)) {
       screenSize.width /= 2;
       screenSize.height /= 2;
     }
@@ -91,7 +93,7 @@ public class RoboGraphics extends Graphics {
 
   @Override protected Canvas createCanvasImpl (Scale scale, int pixelWidth, int pixelHeight) {
     return new RoboCanvas(this, new RoboCanvasImage(this, scale, pixelWidth, pixelHeight,
-                                                    plat.config.interpolateCanvasDrawing));
+                                                    config.interpolateCanvasDrawing));
   }
 
   static CGBitmapContext createCGBitmap(int width, int height) {

--- a/robovm/src/playn/robovm/RoboGraphics.java
+++ b/robovm/src/playn/robovm/RoboGraphics.java
@@ -107,16 +107,15 @@ public class RoboGraphics extends Graphics {
     defaultFramebuffer = gl.glGetInteger(GL20.GL_FRAMEBUFFER_BINDING);
     if (defaultFramebuffer == 0) throw new IllegalStateException(
       "Failed to determine defaultFramebuffer");
-    setSize(bounds);
+    setSize(scale.scaledCeil((float)bounds.getWidth()), scale.scaledCeil((float)bounds.getHeight()));
     // TODO: anything else?
   }
 
-  // called when our view changes size (at init, and when it rotates)
-  public void setSize(CGRect bounds) {
+  void setSize(CGRect bounds) {
     // boolean useHalfSize = useHalfSize(plat);
     int viewWidth = scale.scaledCeil((float)bounds.getWidth());
     int viewHeight = scale.scaledCeil((float)bounds.getHeight());
-    viewportChanged(scale, viewWidth, viewHeight);
+    setSize(viewWidth, viewHeight);
 
     // System.err.println("Screen size " + screenSize());
     // System.err.println("View size " + viewSize + " " + viewWidth + "x" + viewHeight);

--- a/robovm/src/playn/robovm/RoboPlatform.java
+++ b/robovm/src/playn/robovm/RoboPlatform.java
@@ -24,7 +24,6 @@ import org.robovm.apple.glkit.GLKViewDrawableColorFormat;
 import org.robovm.apple.opengles.EAGLContext;
 import org.robovm.apple.uikit.UIApplication;
 import org.robovm.apple.uikit.UIDevice;
-import org.robovm.apple.uikit.UIInterfaceOrientation;
 import org.robovm.apple.uikit.UIInterfaceOrientationMask;
 import org.robovm.apple.uikit.UIWindow;
 import org.robovm.objc.Selector;
@@ -135,7 +134,7 @@ public class RoboPlatform extends Platform {
   protected RoboPlatform(Config config, CGRect initBounds) {
     this.config = config;
     assets = new RoboAssets(this);
-    graphics = new RoboGraphics(this, initBounds);
+    graphics = new RoboGraphics(this, config, initBounds);
     input = new RoboInput(this);
     net = new RoboNet(exec);
     storage = new RoboStorage(this);


### PR DESCRIPTION
We're working a project in which we need to replay the game and record it into video on every platform, in which case, it's really not necessary to load the whole platform and Graphics is good enough. In addition, the graphic related configuration is all platform specific graphics need.

This commit will cause code breaks for registering additional fonts on specific platforms. Those can be easily fixed by calling the plat.assets().getFont() or equivalent methods on specific platforms. 