### PR TITLE
Add possibility to bulk add\remove layers to GroupLayer

### DIFF
--- a/scene/src/playn/scene/GroupLayer.java
+++ b/scene/src/playn/scene/GroupLayer.java
@@ -68,26 +68,28 @@ public class GroupLayer extends ClippedLayer implements Iterable<Layer> {
    * {@code child} is already a child of another {@link GroupLayer}, it will be removed before
    * being added to this {@link GroupLayer}.
    */
-  public void add(Layer child) {
-    // optimization if we're requested to add a child that's already added
-    GroupLayer parent = child.parent();
-    if (parent == this) return;
+  public void add(Layer... childrenForAdd) {
+    for (Layer child : childrenForAdd) {
+      // optimization if we're requested to add a child that's already added
+      GroupLayer parent = child.parent();
+      if (parent == this) return;
 
-    // if this child has equal or greater depth to the last child, we can append directly and avoid
-    // a log(N) search; this is helpful when all children have the same depth
-    int count = children.size(), index;
-    if (count == 0 || children.get(count-1).depth() <= child.depth()) index = count;
-    // otherwise find the appropriate insertion point via binary search
-    else index = findInsertion(child.depth());
+      // if this child has equal or greater depth to the last child, we can append directly and avoid
+      // a log(N) search; this is helpful when all children have the same depth
+      int count = children.size(), index;
+      if (count == 0 || children.get(count - 1).depth() <= child.depth()) index = count;
+        // otherwise find the appropriate insertion point via binary search
+      else index = findInsertion(child.depth());
 
-    // remove the child from any existing parent, preventing multiple parents
-    if (parent != null) parent.remove(child);
-    children.add(index, child);
-    child.setParent(this);
-    if (state.get() == State.ADDED) child.onAdd();
+      // remove the child from any existing parent, preventing multiple parents
+      if (parent != null) parent.remove(child);
+      children.add(index, child);
+      child.setParent(this);
+      if (state.get() == State.ADDED) child.onAdd();
 
-    // if this child is active, we need to become active
-    if (child.interactive()) setInteractive(true);
+      // if this child is active, we need to become active
+      if (child.interactive()) setInteractive(true);
+    }
   }
 
   /**
@@ -124,14 +126,16 @@ public class GroupLayer extends ClippedLayer implements Iterable<Layer> {
   /**
    * Removes a layer from the group.
    */
-  public void remove(Layer child) {
-    int index = findChild(child, child.depth());
-    if (index < 0) {
-      throw new UnsupportedOperationException(
-        "Could not remove Layer because it is not a child of the GroupLayer " +
-          "[group=" + this + ", layer=" + child + "]");
+  public void remove(Layer... childrenForRemove) {
+    for (Layer child : childrenForRemove) {
+      int index = findChild(child, child.depth());
+      if (index < 0) {
+        throw new UnsupportedOperationException(
+                "Could not remove Layer because it is not a child of the GroupLayer " +
+                        "[group=" + this + ", layer=" + child + "]");
+      }
+      remove(index);
     }
-    remove(index);
   }
 
   /**


### PR DESCRIPTION
It would be nice to have ability to bulk add or remove layers to GroupLayer. This small fix add it.

For example if I want to add four layers.

current code:
```Java
GroupLayer groupLayer=new GroupLayer();
// createLayer just creating new ImageLayer and set tint.
ImageLayer layerGray = createLayer(testImage,Colors.GRAY);
ImageLayer layerRed = createLayer(testImage,Colors.RED);
ImageLayer layerGreen = createLayer(testImage,Colors.darker(Colors.GREEN));
ImageLayer layerMagenta = createLayer(testImage,Colors.brighter(Colors.MAGENTA));
// ... set layer params
groupLayer.add(layerGray);
groupLayer.add(layerRed);
groupLayer.add(layerGreen);
groupLayer.add(layerMagenta);
```
new code:
```Java
GroupLayer groupLayer=new GroupLayer();
// createLayer just creating new ImageLayer and set tint.
ImageLayer layerGray = createLayer(testImage,Colors.GRAY);
ImageLayer layerRed = createLayer(testImage,Colors.RED);
ImageLayer layerGreen = createLayer(testImage,Colors.darker(Colors.GREEN));
ImageLayer layerMagenta = createLayer(testImage,Colors.brighter(Colors.MAGENTA));
// ... set layer params
add(layerGray, layerRed, layerGreen, layerMagenta);
```
The same will be with remove layer method.
It's small but useful fix. We can't brake anything.