### PR TITLE
IE11 mouseWheel fixed

### DIFF
--- a/html/src/playn/html/HtmlInput.java
+++ b/html/src/playn/html/HtmlInput.java
@@ -401,7 +401,7 @@ public class HtmlInput extends Input {
         // on mac
         delta = -1.0 * evt.wheelDelta/40;
       }
-    } else if (agentInfo.isChrome || agentInfo.isSafari) {
+    } else if (agentInfo.isChrome || agentInfo.isSafari || agentInfo.isIE) {
       delta = -1.0 * evt.wheelDelta/120;
       // handle touchpad for chrome
       if (Math.abs(delta) < 1) {

--- a/html/src/playn/html/HtmlPlatform.java
+++ b/html/src/playn/html/HtmlPlatform.java
@@ -243,7 +243,7 @@ public class HtmlPlatform extends Platform {
       isChrome: userAgent.indexOf("chrome") != -1,
       isSafari: userAgent.indexOf("safari") != -1,
       isOpera: userAgent.indexOf("opera") != -1,
-      isIE: userAgent.indexOf("msie") != -1,
+      isIE: userAgent.indexOf("msie") != -1 || userAgent.indexOf("trident") != -1,
       // OS type flags
       isMacOS: userAgent.indexOf("mac") != -1,
       isLinux: userAgent.indexOf("linux") != -1,


### PR DESCRIPTION
Hi @samskivert 

Here is the UserAgent info from the different windows browsers
```
Edge:   Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"
IE11:   mozilla/5.0 (windows nt 6.1; wow64; trident/7.0; slcc2; .net clr 2.0.50727; .net clr 3.5.30729; .net clr 3.0.30729; media center pc 6.0; .net4.0c; .net4.0e; rv:11.0) like gecko
Chrome: mozilla/5.0 (windows nt 6.1; win64; x64) applewebkit/537.36 (khtml, like gecko) chrome/48.0.2564.97 safari/537.36
```

<code>HtmlInput</code> accepts Edge and Chrome as Chrome and IE11 as unknown browser. Therefore WheelVelocity sets to zero.

This PR fixes this