### PR TITLE
Allow specifying fps on HTML platform

### DIFF
--- a/html/src/playn/html/HtmlPlatform.java
+++ b/html/src/playn/html/HtmlPlatform.java
@@ -20,15 +20,11 @@ import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.user.client.Window;
 
 import playn.core.*;
-import playn.html.HtmlUrlParameters.Renderer;
 
 public class HtmlPlatform extends Platform {
 
   /** Configures the PlayN HTML platform. */
   public static class Config {
-    /** Whether to use GL or Canvas mode, or to auto-detect. */
-    public Mode mode = Renderer.requestedMode();
-
     /** Whether the canvas that contains the game should be transparent. */
     public boolean transparentCanvas = false;
 
@@ -50,11 +46,6 @@ public class HtmlPlatform extends Platform {
 
     // Scale up the canvas on fullscreen. Highly experimental.
     public boolean experimentalFullscreen = false;
-  }
-
-  /** Used for {@link Config#mode}. */
-  public static enum Mode {
-    WEBGL, CANVAS, AUTODETECT;
   }
 
   /** Returned by {@link #agentInfo}. */

--- a/html/src/playn/html/HtmlUrlParameters.java
+++ b/html/src/playn/html/HtmlUrlParameters.java
@@ -15,8 +15,6 @@ package playn.html;
 
 import com.google.gwt.user.client.Window;
 
-import playn.html.HtmlPlatform.Mode;
-
 /**
  * Interface providing a central place to document all URL query parameters and values which affect
  * the HTML platform.
@@ -34,22 +32,6 @@ public interface HtmlUrlParameters {
     static final String PARAM_NAME = "log_level";
     static final String TRACE = "TRACE";
     static final String WARN = "WARN";
-  }
-
-  public static class Renderer {
-    static final String CANVAS = "canvas";
-    static final String GL = "gl";
-    static final String PARAM_NAME = "renderer";
-
-    static Mode requestedMode() {
-      String renderer = Window.Location.getParameter(PARAM_NAME);
-      if (CANVAS.equals(renderer)) {
-        return Mode.CANVAS;
-      } else if (GL.equals(renderer)) {
-        return Mode.WEBGL;
-      }
-      return Mode.AUTODETECT;
-    }
   }
 
   /**


### PR DESCRIPTION
While letting the browser control frame render times is a nicer solution, setting a lower fps manually results in your CPU not overheating if rendering is slower than 60 fps, which is ultimately pretty useful.

+ some cleanup of dead code