### PR TITLE
Html image load fix

### DIFF
--- a/html/src/playn/html/HtmlImage.java
+++ b/html/src/playn/html/HtmlImage.java
@@ -49,14 +49,12 @@ public class HtmlImage extends ImageImpl {
     else {
       HtmlInput.addEventListener(img, "load", new EventHandler() {
         @Override public void handleEvent (NativeEvent evt) {
-          pixelWidth = img.getWidth();
-          pixelHeight = img.getHeight();
-          pstate.succeed(HtmlImage.this);
+          succeed(new ImageImpl.Data(Scale.ONE, img, img.getWidth(), img.getHeight()));
         }
       }, false);
       HtmlInput.addEventListener(img, "error", new EventHandler() {
         @Override public void handleEvent(NativeEvent evt) {
-          pstate.fail(new RuntimeException("Error loading image " + img.getSrc()));
+          fail(new RuntimeException("Error loading image " + img.getSrc()));
         }
       }, false);
     }


### PR DESCRIPTION
Call the base class succeed/fail functions on load/error event. 

The reasons for this changes are:  when an image fails to load, then the error image doesn't set (only the status has been changed)