### PR TITLE
Fix handling of negative sizes of the clipping rectangle.

### DIFF
--- a/scene/src/playn/scene/ClippedLayer.java
+++ b/scene/src/playn/scene/ClippedLayer.java
@@ -86,8 +86,16 @@ public abstract class ClippedLayer extends Layer {
       tx.transform(pos.set(-originX, -originY), pos);
       tx.transform(size.set(width, height), size);
       tx.translate(-originX, -originY);
+      if (size.x < 0) {
+        size.x = -size.x;
+        pos.x -= size.x;
+      }
+      if (size.y < 0) {
+        size.y = -size.y;
+        pos.y -= size.y;
+      }
       boolean nonEmpty = surf.startClipped(
-        (int)pos.x, (int)pos.y, Math.round(Math.abs(size.x)), Math.round(Math.abs(size.y)));
+        (int)pos.x, (int)pos.y, Math.round(size.x), Math.round(size.y));
       try {
         if (nonEmpty) paintClipped(surf);
       } finally {


### PR DESCRIPTION
This handles the case where the layer is rotated a multiple of 90
degrees by normalizing the clipping rectangle so that both width
and height are always >0.