### PR TITLE
Replace calls to SharedPreferences.commit() with .apply()

### DIFF
--- a/android/src/playn/android/AndroidStorage.java
+++ b/android/src/playn/android/AndroidStorage.java
@@ -32,12 +32,12 @@ public class AndroidStorage implements Storage {
 
   @Override
   public void setItem(String key, String data) throws RuntimeException {
-    settings.edit().putString(key, data).commit();
+    settings.edit().putString(key, data).apply();
   }
 
   @Override
   public void removeItem(String key) {
-    settings.edit().remove(key).commit();
+    settings.edit().remove(key).apply();
   }
 
   @Override
@@ -59,7 +59,7 @@ public class AndroidStorage implements Storage {
         edit.remove(key);
       }
       @Override protected void onAfterCommit() {
-        edit.commit();
+        edit.apply();
         edit = null;
       }
     };


### PR DESCRIPTION
apply() is faster (commits changes asynchronously), and available
from API level 9. Replacing commit() with apply() is safe in all
cases where the return value from commit() was already being ignored.

Ref: https://developer.android.com/reference/android/content/SharedPreferences.Editor#apply()