### PR TITLE
reference texture before release previous (can be the same)

### DIFF
--- a/scene/src/playn/scene/ImageLayer.java
+++ b/scene/src/playn/scene/ImageLayer.java
@@ -93,10 +93,10 @@ public class ImageLayer extends Layer {
   public ImageLayer setTile (Tile tile) {
     // avoid releasing and rereferencing texture if nothing changes
     if (this.tile != tile) {
+      if (tile != null) tile.texture().reference();
       if (this.tile != null) this.tile.texture().release();
       this.tile = tile;
       checkOrigin();
-      if (tile != null) tile.texture().reference();
     }
     return this;
   }


### PR DESCRIPTION
In the case where the new tile is a subregion of the previous tile's texture, the texture is closed by de-referencing.