### PR TITLE
show soft keyboard automatically on getText

### DIFF
--- a/android/src/playn/android/AndroidInput.java
+++ b/android/src/playn/android/AndroidInput.java
@@ -18,6 +18,7 @@ import android.content.DialogInterface;
 import android.text.InputType;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+import android.view.WindowManager;
 import android.widget.EditText;
 
 import playn.core.*;
@@ -86,7 +87,8 @@ public class AndroidInput extends Input {
             result.succeed(null);
           }
         });
-        alert.show();
+        AlertDialog dialog = alert.show();
+        dialog.getWindow().setSoftInputMode (WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
       }
     });
     return result;


### PR DESCRIPTION
On some android devices a call to getText shows the EditText but doesn't automatically show the soft keyboard, hence the user must touch the textfield once for it to show up. This PR makes it so that the keyboard is shown directly