### PR TITLE
enable passing labels for "ok" and "cancel" labels in getText

### DIFF
--- a/android/src/playn/android/AndroidInput.java
+++ b/android/src/playn/android/AndroidInput.java
@@ -46,7 +46,7 @@ public class AndroidInput extends Input {
   }
 
   @Override public RFuture<String> getText (final Keyboard.TextType ttype, final String label,
-                                            final String initVal) {
+                                            final String initVal, final String ok, final String cancel) {
     final RPromise<String> result = plat.exec().deferredPromise();
     plat.activity.runOnUiThread(new Runnable() {
       public void run () {
@@ -76,13 +76,13 @@ public class AndroidInput extends Input {
         input.setText(initVal);
         alert.setView(input);
 
-        alert.setPositiveButton("Ok", new DialogInterface.OnClickListener() {
+        alert.setPositiveButton(ok, new DialogInterface.OnClickListener() {
           public void onClick(DialogInterface dialog, int whichButton) {
             result.succeed(input.getText().toString());
           }
         });
 
-        alert.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+        alert.setNegativeButton(cancel, new DialogInterface.OnClickListener() {
           public void onClick(DialogInterface dialog, int whichButton) {
             result.succeed(null);
           }

--- a/core/src/playn/core/Input.java
+++ b/core/src/playn/core/Input.java
@@ -94,6 +94,30 @@ public class Input {
    * text entry process, null is supplied. Otherwise the entered text is supplied.
    */
   public RFuture<String> getText (Keyboard.TextType textType, String label, String initialValue) {
+    return getText(textType, label, initialValue, "Ok", "Cancel");
+  }
+
+  /**
+   * Requests a line of text from the user. On platforms that have only a virtual keyboard, this
+   * will display a text entry interface, obtain the line of text, and dismiss the text entry
+   * interface when finished.
+   *
+   * @param textType the expected type of text. On mobile devices this hint may be used to display a
+   * keyboard customized to the particular type of text.
+   * @param label a label to display over the text entry interface, may be null.
+   * @param initialValue the initial value to display in the text input field, may be null.
+   * @param ok the text of the button which will deliver a {@code true} result and be placed in
+   * "OK" position for the platform. Note: the HTML platform does not support customizing this
+   * label, so on that platform the label will be "OK". Yay for HTML5.
+   * @param cancel the text of the button that will deliver a {@code false} result and be placed in
+   * "Cancel" position. If {@code null} is supplied, the dialog will only have an OK button. Note:
+   * the HTML platform does not support customizing this label, so on that platform a non-null
+   * cancel string will result in the button reading "Cancel". Yay for HTML5.
+   *
+   * @return a future which provides the text when it becomes available. If the user cancels the
+   * text entry process, null is supplied. Otherwise the entered text is supplied.
+   */
+  public RFuture<String> getText (Keyboard.TextType textType, String label, String initialValue, String ok, String cancel) {
     return RFuture.failure(new Exception("getText not supported"));
   }
 

--- a/html/src/playn/html/HtmlInput.java
+++ b/html/src/playn/html/HtmlInput.java
@@ -196,7 +196,7 @@ public class HtmlInput extends Input {
   }-*/;
 
   @Override public RFuture<String> getText(Keyboard.TextType textType, String label,
-                                           String initVal) {
+                                           String initVal, String ok, String cancel) {
     String result = Window.prompt(label, initVal);
     emitFakeMouseUp();
     return RFuture.success(result);

--- a/java-lwjgl/src/playn/java/GLFWInput.java
+++ b/java-lwjgl/src/playn/java/GLFWInput.java
@@ -117,7 +117,8 @@ public class GLFWInput extends JavaInput {
     "The java-lwjgl backend does not allow interop with AWT on Mac OS X. " +
     "Use the java-swt backend if you need native dialogs.";
 
-  @Override public RFuture<String> getText(TextType textType, String label, String initVal) {
+  @Override public RFuture<String> getText(TextType textType, String label, String initVal, 
+                                           String ok, String cancel) {
     if (plat.needsHeadless()) throw new UnsupportedOperationException(NO_UI_ERROR);
 
     Object result = JOptionPane.showInputDialog(

--- a/java-lwjgl2/src/playn/java/LWJGLInput.java
+++ b/java-lwjgl2/src/playn/java/LWJGLInput.java
@@ -39,7 +39,8 @@ public class LWJGLInput extends JavaInput {
     }
   }
 
-  @Override public RFuture<String> getText(TextType textType, String label, String initVal) {
+  @Override public RFuture<String> getText(TextType textType, String label, String initVal,
+                                           String ok, String cancel) {
     Object result = JOptionPane.showInputDialog(
       null, label, "", JOptionPane.QUESTION_MESSAGE, null, null, initVal);
     return RFuture.success((String)result);

--- a/java-swt/src/playn/java/SWTInput.java
+++ b/java-swt/src/playn/java/SWTInput.java
@@ -90,8 +90,8 @@ public class SWTInput extends JavaInput {
     });
   }
 
-  @Override public RFuture<String> getText (Keyboard.TextType textType,
-                                            String label, String initVal) {
+  @Override public RFuture<String> getText (Keyboard.TextType textType, String label,
+                                            String initVal, String okLbl, String cancelLbl) {
     final RPromise<String> result = RPromise.create();
 
     final Shell shell = new Shell(plat.shell(), SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
@@ -123,7 +123,7 @@ public class SWTInput extends JavaInput {
     if (initVal != null) text.setText(initVal);
 
     final Button ok = new Button(shell, SWT.PUSH);
-    ok.setText("OK");
+    ok.setText(okLbl);
     ok.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_END));
     ok.addListener(SWT.Selection, new Listener() {
       public void handleEvent(Event event) {
@@ -135,7 +135,7 @@ public class SWTInput extends JavaInput {
     shell.setDefaultButton(ok);
 
     Button cancel = new Button(shell, SWT.PUSH);
-    cancel.setText("Cancel");
+    cancel.setText(cancelLbl);
     cancel.addListener(SWT.Selection, new Listener() {
       public void handleEvent(Event event) {
         shell.dispose();

--- a/robovm/src/playn/robovm/RoboInput.java
+++ b/robovm/src/playn/robovm/RoboInput.java
@@ -43,14 +43,14 @@ public class RoboInput extends Input {
   @Override public boolean hasTouch () { return true; }
 
   @Override public RFuture<String> getText(Keyboard.TextType textType, String label,
-                                           String initVal) {
+                                           String initVal, String ok, String cancel) {
     final RPromise<String> result = plat.exec().deferredPromise();
 
     UIAlertView view = new UIAlertView();
     if (label != null)
       view.setTitle(label);
-    view.addButton("Cancel");
-    view.addButton("OK");
+    view.addButton(cancel);
+    view.addButton(ok);
     view.setAlertViewStyle(UIAlertViewStyle.PlainTextInput);
 
     final UITextField field = view.getTextField(0);


### PR DESCRIPTION
I noticed that getText had hardcoded "Ok" and "Cancel" as labels for the buttons (like sysDialog does). This PR fixes it, while being backwards compatible with those labels as defaults