### PR TITLE
NSTimer created in RoboPlatform.willTerminate would never fire.

### DIFF
--- a/robovm/src/playn/robovm/RoboPlatform.java
+++ b/robovm/src/playn/robovm/RoboPlatform.java
@@ -198,7 +198,7 @@ public class RoboPlatform extends Platform {
         // stop and release the AL resources (if audio was ever initialized)
         if (audio != null) audio.terminate();
       }
-    }, null, false);
+    }, null, false, true);
     // let the app know that we're terminating
     dispatchEvent(lifecycle, Lifecycle.EXIT);
   }


### PR DESCRIPTION
The current code ends up calling the native `timerWithTimeInterval:target:selector:userInfo:repeats:` method. This creates the timer but does not start it (it does not add it to a run loop).

With this commit, the `scheduledTimerWithTimeInterval:target:selector:userInfo:repeats:` is used instead, which creates *and* schedules the timer.