### PR TITLE
Fix memory leak.

### DIFF
--- a/robovm/src/playn/robovm/RoboPlatform.java
+++ b/robovm/src/playn/robovm/RoboPlatform.java
@@ -187,6 +187,7 @@ public class RoboPlatform extends Platform {
   }
 
   void willTerminate () {
+    pool.shutdown();
     // let the app know that we're terminating
     dispatchEvent(lifecycle, Lifecycle.EXIT);
   }


### PR DESCRIPTION
Not shutting down the thread pool was preventing the
RoboPlatform from being GC'ed when not in use anymore.