### PR TITLE
Use UIScreen.nativeScale instead of scale where available (iOS 8+)

### DIFF
--- a/robovm/src/playn/robovm/RoboGraphics.java
+++ b/robovm/src/playn/robovm/RoboGraphics.java
@@ -18,6 +18,7 @@ import org.robovm.apple.coregraphics.CGBitmapInfo;
 import org.robovm.apple.coregraphics.CGColorSpace;
 import org.robovm.apple.coregraphics.CGImageAlphaInfo;
 import org.robovm.apple.coregraphics.CGRect;
+import org.robovm.apple.foundation.Foundation;
 import org.robovm.apple.uikit.UIDevice;
 import org.robovm.apple.uikit.UIDeviceOrientation;
 import org.robovm.apple.uikit.UIScreen;
@@ -53,7 +54,9 @@ public class RoboGraphics extends Graphics {
     return isPad && config.iPadLikePhone;
   }
   private static Scale viewScale (RoboPlatform.Config config) {
-    float deviceScale = (float)UIScreen.getMainScreen().getScale();
+    float deviceScale = (float)((Foundation.getMajorSystemVersion() >= 8)
+                                    ? UIScreen.getMainScreen().getNativeScale()
+                                    : UIScreen.getMainScreen().getScale());
     boolean useHalfSize = useHalfSize(config);
     return new Scale((useHalfSize ? 2 : 1) * deviceScale);
   }


### PR DESCRIPTION
Starting with iOS 8.0, UIScreen.nativeScale should be used to convert
from points to physical device pixels. In many cases, the "native scale"
and "scale" values match, but there are some exceptions:
 - Devices that perform hardware downsampling (iPhone 6+/6s+/7+/8+)
 - Devices supporting zoomed display mode (all iPhone 6/7/8 variants),
   when display mode is enabled.

This fixes #78.