### PR TITLE
Fix rendering issue in fillRoundRect/strokeRoundRect

### DIFF
--- a/android/src/playn/android/AndroidCanvas.java
+++ b/android/src/playn/android/AndroidCanvas.java
@@ -136,11 +136,8 @@ public class AndroidCanvas extends Canvas {
   }
 
   @Override public Canvas fillRoundRect(float x, float y, float width, float height, float radius) {
-    // for some reason setting x, y to non-zero causes the round rect to be distorted
-    canvas.translate(x, y);
-    rectf.set(0, 0, width, height);
+    rectf.set(x, y, x + width, y + height);
     canvas.drawRoundRect(rectf, radius, radius, currentState().prepareFill());
-    canvas.translate(-x, -y);
     isDirty = true;
     return this;
   }
@@ -254,11 +251,8 @@ public class AndroidCanvas extends Canvas {
 
   @Override public Canvas strokeRoundRect(float x, float y, float width, float height,
                                           float radius) {
-    // for some reason setting x, y to non-zero causes the round rect to be distorted
-    canvas.translate(x, y);
-    rectf.set(0, 0, width, height);
+    rectf.set(x, y, x + width, y + height);
     canvas.drawRoundRect(rectf, radius, radius, currentState().prepareStroke());
-    canvas.translate(-x, -y);
     isDirty = true;
     return this;
   }


### PR DESCRIPTION
There is a problem in AndroidCanvas.fillRoundRect() related to gradient fills.
Here's a test that fills some round rects using a linear gradient:

    Linear config = new Linear(0, 0, width, 0,
        new int[] { 0xffff0000, 0xff00ff00, 0xff0000ff },
        new float[] { 0f, 0.5f, 1f });
    Gradient gradient = canvas.createGradient(config);

    canvas.setFillGradient(gradient);
    canvas.fillRoundRect(0, 120, width, 50, 5);
    canvas.fillRoundRect(0, 180, width / 2 - 5, 50, 5);
    canvas.fillRoundRect(width / 2 + 5, 180, width / 2 - 5, 50, 5);

This is how it should look like:

![image](https://user-images.githubusercontent.com/2486184/99652717-75fdfb80-2a58-11eb-88c3-4d19642ecdf2.png)

This is how it looks like in Android:

![image](https://user-images.githubusercontent.com/2486184/99652851-a04fb900-2a58-11eb-9f14-1ab9f925c5f9.png)

The problem is that the origin for the gradient fill is reset to the origin of each shape (see the rectangle in the bottom right).

This seems to be due to the [current implementation of AndroidCanvas.fillRoundRect](https://github.com/playn/playn/blob/59c4f4209507ef5fd72f487434300273dd7bdde1/android/src/playn/android/AndroidCanvas.java#L138), which translates the canvas, draws using a rect at (0, 0), and then translates it back. The translation is what is causing the issue with gradient fills.

The translate calls were introduced [in this commit](ab72fb60845312a2cb2815874f1ad995d89d90f0) to fix a bug when the rect supplied to drawRoundRect had non-zero x or y. However, the problem was actually related to the coords passed to the rect (the two last parameters should be the right and bottom coords, not the width and height).

This PR fixes this issue by passing the right coords to the rect and removing the translate calls.

Another option would be to use the drawRoundRect method that takes (x, y, width, height) instead of a Rect, and avoid the creation of an intermediate Rect. However this was introduced in API level 21 which doesn't work if building PlayN using Maven (android.version is currently set to 4.1.1.4, which is the latest version available in Maven central).
