### PR TITLE
Canvas: add some missing calls to save/restore state

### DIFF
--- a/robovm/src/playn/robovm/RoboCanvas.java
+++ b/robovm/src/playn/robovm/RoboCanvas.java
@@ -144,8 +144,10 @@ public class RoboCanvas extends Canvas {
       CGMutablePath cgPath = CGMutablePath.createMutable();
       cgPath.addArc(null, x, y, radius, 0, 2*Math.PI, false);
       bctx.addPath(cgPath);
+      bctx.saveGState();
       bctx.clip();
       gradient.fill(bctx);
+      bctx.restoreGState();
     }
     isDirty = true;
     return this;
@@ -157,8 +159,10 @@ public class RoboCanvas extends Canvas {
     if (gradient == null) {
       bctx.fillPath();
     } else {
+      bctx.saveGState();
       bctx.clip();
       gradient.fill(bctx);
+      bctx.restoreGState();
     }
     isDirty = true;
     return this;
@@ -184,8 +188,10 @@ public class RoboCanvas extends Canvas {
     if (gradient == null) {
       bctx.fillPath();
     } else {
+      bctx.saveGState();
       bctx.clip();
       gradient.fill(bctx);
+      bctx.restoreGState();
     }
     isDirty = true;
     return this;


### PR DESCRIPTION
Some methods were missing calls to save/restore state when used with gradients. The clip was being modified internally and resulting in incorrect results for subsequent drawing operations.
