### PR TITLE
Regenerate region tiles from disposed textures

### DIFF
--- a/core/src/playn/core/Image.java
+++ b/core/src/playn/core/Image.java
@@ -197,7 +197,8 @@ public abstract class Image extends TileSource implements Canvas.Drawable, Close
       private Tile tile;
       @Override public boolean isLoaded () { return image.isLoaded(); }
       @Override public Tile tile () {
-        if (tile == null) tile = image.texture().tile(rx, ry, rwidth, rheight);
+        if (tile == null || tile.texture().disposed())
+          tile = image.texture().tile(rx, ry, rwidth, rheight);
         return tile;
       }
       @Override public RFuture<Tile> tileAsync () {


### PR DESCRIPTION
Regions were caching tile instances which may refer to textures that
may already have been disposed. Now this is detected when tile()
is called and a new tile is created from the new texture.