### PR TITLE
Fix text rendering for non-integer font sizes

### DIFF
--- a/android/src/playn/android/AndroidTextLayout.java
+++ b/android/src/playn/android/AndroidTextLayout.java
@@ -39,6 +39,7 @@ class AndroidTextLayout extends TextLayout {
     paint.setTypeface(font.typeface);
     paint.setTextSize(font.size);
     paint.setSubpixelText(true);
+    paint.setLinearText(true);
     Paint.FontMetrics metrics = paint.getFontMetrics();
     return new AndroidTextLayout(text, format, font, metrics, paint.measureText(text));
   }
@@ -50,6 +51,7 @@ class AndroidTextLayout extends TextLayout {
     paint.setTypeface(font.typeface);
     paint.setTextSize(font.size);
     paint.setSubpixelText(true);
+    paint.setLinearText(true);
     Paint.FontMetrics metrics = paint.getFontMetrics();
 
     List<TextLayout> layouts = new ArrayList<TextLayout>();
@@ -144,6 +146,7 @@ class AndroidTextLayout extends TextLayout {
       paint.setTypeface(font.typeface);
       paint.setTextSize(font.size);
       paint.setSubpixelText(true);
+      paint.setLinearText(true);
 
       // if we're drawing REALLY BIG TEXT, draw to a path rather than directly drawing text to work
       // around KitKat bug: https://code.google.com/p/android/issues/detail?id=62800


### PR DESCRIPTION
Set the LINEAR_TEXT_FLAG to fix text rendering when using non-integer font sizes. Without this, the extent of text runs for non-integer font sizes seems to be calculated based on integer sizes, and the letter spacing seems to be wrong.

After this change, the rendering of text in Android is much closer to the results when using PlayN on robovm/iOS.

Before the change:
![Android 10 - non linear](https://user-images.githubusercontent.com/74895131/201333892-c59d9bf8-d26b-463a-b23f-c0c5a7532522.png)

Notice how the glyphs of the 12.5 font are noticeable larger than the ones of the 12 font, but the line width is the same.

After the change:
![Android 10 - linear](https://user-images.githubusercontent.com/74895131/201333895-40d14532-7076-4db5-9207-4e280179e52b.png)

(Tests made in Android 10)