### PR TITLE
html: Support setting width/height in Config object

### DIFF
--- a/html/src/playn/html/HtmlGraphics.java
+++ b/html/src/playn/html/HtmlGraphics.java
@@ -77,14 +77,24 @@ public class HtmlGraphics extends Graphics {
     dummyCtx = dummyCanvas.getContext2d();
 
     Element root = doc.getElementById(config.rootId);
+    int width = config.width;
+    int height = config.height;
     if (root == null) {
       root = doc.createDivElement();
-      root.setAttribute("style", "width: 640px; height: 480px");
+      if (width == 0 || height == 0) {
+        width = 640;
+        height = 480;
+      }
       doc.getBody().appendChild(root);
     } else {
       // clear the contents of the root element, if present
       root.setInnerHTML("");
     }
+
+    if (width > 0 && height > 0) {
+      root.setAttribute("style", "width: " + width + "px; height: " + height + "px");
+    }
+
     rootElement = root;
 
     // create a hidden element used to measure font heights

--- a/html/src/playn/html/HtmlPlatform.java
+++ b/html/src/playn/html/HtmlPlatform.java
@@ -44,6 +44,14 @@ public class HtmlPlatform extends Platform {
     /** The id of the {@code <div>} element where the game will be inserted. */
     public String rootId = "playn-root";
 
+    /** The width of the root element, to be set as an inline style.
+     *  Ignored if either width or height are {@code 0} (the default). */
+    public int width = 0;
+
+    /** The height of the root element, to be set as an inline style.
+     *  Ignored if either width or height are {@code 0} (the default). */
+    public int height = 0;
+
     /** If {@code > 0}, the period (in milliseconds) at which to fire frame signals when paused.
       * If {@code 0} (the default) no frame signals will be fired when paused. */
     public int backgroundFrameMillis = 0;


### PR DESCRIPTION
For the html background, this change allows configuring the width/height of the root element in the HtmlPlatform.Config object. If both width and height are non-zero, then these are configured in the root node as inline styles. If any of the two is 0 (the default) the current behaviour is kept.

I believe that for simple use cases this is slightly more developer-friendly than having to customize the default index.html page. Also it is consistent with the width/height options in the Java backend.