### PR TITLE
Add GH action to run a build on every PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Check out PlayN
+        uses: actions/checkout@v4
+
+      - name: Build and run test
+        run: mvn -B install
+


### PR DESCRIPTION
This adds a GitHub action that runs a build (along with all tests) on every PR that is created or updated.

PRs won't be mergeable if the build fails (unless the action is overriden).
