### PR TITLE
Surface: Add drawRect method

### DIFF
--- a/core/src/playn/core/Surface.java
+++ b/core/src/playn/core/Surface.java
@@ -380,6 +380,19 @@ public class Surface implements Closeable {
   }
 
   /**
+   * Draws the specified rectangle.
+   * This is implemented by drawing four lines corresponding to the rectangle edges.
+   */
+  public Surface drawRect (float x, float y, float width, float height, float lineWidth) {
+    float cap = lineWidth / 2;
+    drawLine(x - cap, y, x + width + cap, y, lineWidth);
+    drawLine(x - cap, y + height, x + width + cap, y + height, lineWidth);
+    drawLine(x, y, x, y + height, lineWidth);
+    drawLine(x + width, y, x + width, y + height, lineWidth);
+    return this;
+  }
+
+  /**
    * Fills the specified rectangle.
    */
   public Surface fillRect (float x, float y, float width, float height) {

--- a/core/src/playn/core/Surface.java
+++ b/core/src/playn/core/Surface.java
@@ -386,9 +386,9 @@ public class Surface implements Closeable {
   public Surface drawRect (float x, float y, float width, float height, float lineWidth) {
     float cap = lineWidth / 2;
     drawLine(x - cap, y, x + width + cap, y, lineWidth);
-    drawLine(x - cap, y + height, x + width + cap, y + height, lineWidth);
-    drawLine(x, y, x, y + height, lineWidth);
-    drawLine(x + width, y, x + width, y + height, lineWidth);
+    drawLine(x + width, y + cap, x + width, y + height - cap, lineWidth);
+    drawLine(x + width + cap, y + height, x - cap, y + height, lineWidth);
+    drawLine(x, y + height - cap, x, y + cap, lineWidth);
     return this;
   }
 


### PR DESCRIPTION
This adds a method to draw the outline of a rectangle, with the specified line width. This is implemented internally as a set of 4 calls to drawLine.

I know that the Surface API should be kept as simple as possible and map to accelerated GPU primitives but it feels strange to have a fillRect method and not a corresponding drawRect. Also the implementation is simple enough so I think it's worth adding this.