### PR TITLE
Trim whitespace from text in TextLayout.

### DIFF
--- a/core/src/playn/core/Graphics.java
+++ b/core/src/playn/core/Graphics.java
@@ -149,12 +149,16 @@ public abstract class Graphics {
   /**
    * Lays out a single line of text using the specified format. The text may subsequently be
    * rendered on a canvas via {@link Canvas#fillText (TextLayout,float,float)}.
+   * @param text the text to be laid out. Note: whitespace will be trimmed from the start and end
+   * of the text to avoid inconsistencies with text measurement on different platforms.
    */
   public abstract TextLayout layoutText (String text, TextFormat format);
 
   /**
    * Lays out multiple lines of text using the specified format and wrap configuration. The text
    * may subsequently be rendered on a canvas via {@link Canvas#fillText (TextLayout,float,float)}.
+   * @param text the text to be laid out. Note: whitespace will be trimmed from the start and end
+   * of the text to avoid inconsistencies with text measurement on different platforms.
    */
   public abstract TextLayout[] layoutText (String text, TextFormat format, TextWrap wrap);
 

--- a/core/src/playn/core/TextLayout.java
+++ b/core/src/playn/core/TextLayout.java
@@ -53,7 +53,7 @@ public abstract class TextLayout {
   public abstract float leading ();
 
   protected TextLayout (String text, TextFormat format, IRectangle bounds, float height) {
-    this.text = text;
+    this.text = text.trim();
     this.format = format;
     this.bounds = bounds;
     // if the x position is positive, we need to include extra space in our full-width for it


### PR DESCRIPTION
This avoids inconsistencies in handling of leading/trailing whitespace when measuring text on different platforms.